### PR TITLE
fix: use undici from >=16.8x rather than >=16.5x

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ let uniFetch: Fetch;
 /* istanbul ignore next */
 if (nodeMajor >= 18) {
   uniFetch = globalThis;
-} else if (nodeMajor > 16 || (nodeMajor === 16 && nodeMinor >= 5)) {
+} else if (nodeMajor > 16 || (nodeMajor === 16 && nodeMinor >= 8)) {
   // TODO: Type this as undici once it has the same type signature as the globals
   uniFetch = require("undici");
 } else {


### PR DESCRIPTION
Matches https://github.com/nodejs/undici/pull/1534/files#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R83

<!-- When fixing a bug: -->

This PR fixes #<issue ID>.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
