### PR TITLE
fix(exports): fix browser export paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     }
   },
   "browser": {
-    "dist/index.js": "dist/index-browser.js",
-    "dist/index.es.js": "dist/index-browser.es.js",
-    "dist/index.mjs": "dist/index-browser.mjs"
+    "dist/index.js": "./dist/index-browser.js",
+    "dist/index.es.js": "./dist/index-browser.es.js",
+    "dist/index.mjs": "./dist/index-browser.mjs"
   },
   "files": [
     "dist",


### PR DESCRIPTION
The problems seen in NextJS came from the paths not resolving correctly because we were defining absolute paths rather than relative paths in the browser exports.