### PR TITLE
chore: dont include src files in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   },
   "files": [
     "dist",
-    "src",
     "umd"
   ],
   "sideEffects": false,


### PR DESCRIPTION
Don't include the `src` files in the packaged result as everything consumers need is in the `dist` or `umd` directory.