### PR TITLE
Fix browser bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/dotenv-flow": "^3.2.0",
         "@types/jest": "^28.1.3",
         "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.2",
         "dotenv-flow": "^3.2.0",
         "jest": "^28.1.1",
         "jest-environment-node": "^29.4.3",
@@ -1502,6 +1503,16 @@
       "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
       "dev": true
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
     "node_modules/@types/prettier": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
@@ -1897,6 +1908,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -2223,6 +2240,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -2316,6 +2345,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-newline": {
@@ -3155,6 +3193,20 @@
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs-extra": {
@@ -5240,6 +5292,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -8010,6 +8083,16 @@
       "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
       "dev": true
     },
+    "@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
     "@types/prettier": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
@@ -8261,6 +8344,12 @@
         "es-shim-unscopables": "^1.0.0"
       }
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
     "available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -8500,6 +8589,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -8574,6 +8672,12 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -9210,6 +9314,17 @@
       "dev": true,
       "requires": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       }
     },
     "fs-extra": {
@@ -10798,6 +10913,21 @@
       "requires": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
+      }
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.52.0"
       }
     },
     "mimic-fn": {

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     }
   },
   "browser": {
-    "dist/index.js": "./dist/index-browser.js",
-    "dist/index.es.js": "./dist/index-browser.es.js",
-    "dist/index.mjs": "./dist/index-browser.mjs"
+    "./dist/index.js": "./dist/index-browser.js",
+    "./dist/index.es.js": "./dist/index-browser.es.js",
+    "./dist/index.mjs": "./dist/index-browser.mjs"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -39,11 +39,7 @@
       "import": "./dist/index.mjs"
     }
   },
-  "browser": {
-    "./dist/index.js": "./dist/index-browser.js",
-    "./dist/index.es.js": "./dist/index-browser.es.js",
-    "./dist/index.mjs": "./dist/index-browser.mjs"
-  },
+  "browser": "./dist/index-browser.js",
   "files": [
     "dist",
     "umd"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
       "import": "./dist/index.mjs"
     }
   },
-  "browser": "./dist/index-browser.js",
   "files": [
     "dist",
     "umd"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
       "import": "./dist/index.mjs"
     }
   },
+  "browser": {
+    "undici": false,
+    "node-fetch": false
+  },
   "files": [
     "dist",
     "umd"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/dotenv-flow": "^3.2.0",
     "@types/jest": "^28.1.3",
     "@types/node": "^18.11.18",
+    "@types/node-fetch": "^2.6.2",
     "dotenv-flow": "^3.2.0",
     "jest": "^28.1.1",
     "jest-environment-node": "^29.4.3",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,35 +1,36 @@
-/**
- * Copyright 2020 Inrupt Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal in
- * the Software without restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
- * Software, and to permit persons to whom the Software is furnished to do so,
- * subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
- * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
- * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
- * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- */
+//
+// Copyright 2022 Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
 
 // The following is only possible from Node 18 onwards
 // import pkg from "./package.json" assert { type: "json" };
 
 // Until we only support Node 18+, this should be used instead
-// (see https://rollupjs.org/guide/en/#importing-packagejson) 
-import { createRequire } from 'node:module';
-const require = createRequire(import.meta.url);
-const pkg = require('./package.json');
+// (see https://rollupjs.org/guide/en/#importing-packagejson)
+import { createRequire } from "node:module";
 
 import typescript from "rollup-plugin-typescript2";
 import { readFileSync } from "fs";
+
+const require = createRequire(import.meta.url);
+const pkg = require("./package.json");
 
 // Hack to be able to read tsconfig and append an excludes rule:
 // Note: this does only remove single line comments.
@@ -72,7 +73,7 @@ export default [
         exports: "named",
       },
     ],
-    plugins: plugins,
+    plugins,
     external: [],
   },
   {
@@ -101,7 +102,7 @@ export default [
         exports: "named",
       },
     ],
-    plugins: plugins,
+    plugins,
     external: [],
   },
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,14 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+import Undici from "undici";
+// @ts-ignore
+import NodeFetch, {
+  Headers as NodeHeaders,
+  Request as NodeRequest,
+  Response as NodeResponse,
+} from "node-fetch";
+
 interface Fetch {
   fetch: typeof globalThis.fetch;
   Headers: typeof globalThis.Headers;
@@ -63,16 +71,15 @@ if (typeof window !== "undefined") {
   if (nodeMajor >= 18) {
     uniFetch = globalThis;
   } else if (nodeMajor > 16 || (nodeMajor === 16 && nodeMinor >= 8)) {
-    uniFetch = require("undici");
+    uniFetch = Undici as any;
   } else {
     uniFetch = {
-      fetch: require("node-fetch").default,
-      Headers: require("node-fetch").Headers,
-      Request: require("node-fetch").Request,
-      Response: require("node-fetch").Response,
+      fetch: NodeFetch,
+      Headers: NodeHeaders,
+      Request: NodeRequest,
+      Response: NodeResponse,
     };
   }
 }
-
 export default uniFetch.fetch;
 export const { fetch, Request, Response, Headers } = uniFetch;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,28 +26,52 @@ interface Fetch {
   Response: typeof globalThis.Response;
 }
 
-const nodeVersion = process.versions.node.split(".");
-const nodeMajor = Number(nodeVersion[0]);
-const nodeMinor = Number(nodeVersion[1]);
+// const nodeVersion = process.versions.node.split(".");
+// const nodeMajor = Number(nodeVersion[0]);
+// const nodeMinor = Number(nodeVersion[1]);
 
-let uniFetch: Fetch;
+// let uniFetch: Fetch;
 
-// Each branch is pre-determined based on node version and hence any test on a given node version will
-// not reach a particular branch.
-/* istanbul ignore next */
-if (nodeMajor >= 18) {
+// /* istanbul ignore next */
+// if (nodeMajor >= 18) {
+//   uniFetch = globalThis;
+// } else if (nodeMajor > 16 || (nodeMajor === 16 && nodeMinor >= 8)) {
+//   // TODO: Type this as undici once it has the same type signature as the globals
+//   uniFetch = require("undici");
+// } else {
+//   // TODO: Fix this type casting once node-fetch has the same type signature as the globals
+//   uniFetch = {
+//     fetch: require("node-fetch").default as typeof globalThis.fetch,
+//     Headers: require("node-fetch").Headers as typeof globalThis.Headers,
+//     Request: require("node-fetch").Request as typeof globalThis.Request,
+//     Response: require("node-fetch").Response as typeof globalThis.Response,
+//   };
+// }
+
+// export default uniFetch.fetch;
+// export const { fetch, Request, Response, Headers } = uniFetch;
+
+let uniFetch;
+if (typeof window !== "undefined") {
   uniFetch = globalThis;
-} else if (nodeMajor > 16 || (nodeMajor === 16 && nodeMinor >= 8)) {
-  // TODO: Type this as undici once it has the same type signature as the globals
-  uniFetch = require("undici");
 } else {
-  // TODO: Fix this type casting once node-fetch has the same type signature as the globals
-  uniFetch = {
-    fetch: require("node-fetch").default as typeof globalThis.fetch,
-    Headers: require("node-fetch").Headers as typeof globalThis.Headers,
-    Request: require("node-fetch").Request as typeof globalThis.Request,
-    Response: require("node-fetch").Response as typeof globalThis.Response,
-  };
+  // Each branch is pre-determined based on node version and hence any test on a given node version will
+  // not reach a particular branch.
+  const nodeVersion = process.versions.node.split(".");
+  const nodeMajor = Number(nodeVersion[0]);
+  const nodeMinor = Number(nodeVersion[1]);
+  if (nodeMajor >= 18) {
+    uniFetch = globalThis;
+  } else if (nodeMajor > 16 || (nodeMajor === 16 && nodeMinor >= 8)) {
+    uniFetch = require("undici");
+  } else {
+    uniFetch = {
+      fetch: require("node-fetch").default,
+      Headers: require("node-fetch").Headers,
+      Request: require("node-fetch").Request,
+      Response: require("node-fetch").Response,
+    };
+  }
 }
 
 export default uniFetch.fetch;


### PR DESCRIPTION
The `browser` entry in the `package.json` resulted in undesirable behaviors, leading to Webpack not being able to bundle the library appropriately. This resolves the issue by removing the separation between the browser and the node exports, as well as excluding from the browser bundle parts that are going to be only required in Node.
The previous usage of `require` was leading to incompatibilities with usage in an ESM environment, which is now taken care of by rollup when emitting the output after transpiling TS.

See the commit history for a peek at the different experimentations to get this working :)

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
