### PR TITLE
chore: only skip running e2e tests for dependabot

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -10,10 +10,6 @@ concurrency:
   cancel-in-progress: true
 jobs:
   e2e-browser:
-    # Dependabot cannot access secrets, so it doesn't have a token to authenticate to ESS.
-    # Since all the other jobs of this workflow depend on this one, skipping it should
-    # skip the entire workflow.
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     environment:
       name: ${{ matrix.environment-name }}
@@ -37,7 +33,11 @@ jobs:
       - run: npm run build
       - run: npx playwright install --with-deps
       - run: npm run test:e2e:browser:setup
-      - run: npm run test:e2e:browser
+      - # Dependabot cannot access secrets, so it doesn't have a token to authenticate to ESS.
+        # Since all the other jobs of this workflow depend on this one, skipping it should
+        # skip the entire workflow.
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        run: npm run test:e2e:browser
       - name: Archive browser-based end-to-end test request logs
         uses: actions/upload-artifact@v3
         if: failure()


### PR DESCRIPTION
If we skip the entire test suite then dependabot PRs cannot be merged as this is a required CI check and it gets skipped

