### PR TITLE
fix: fixes rollup resolution for browser bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,10 @@
   "browser": {
     "dist/index.js": "./dist/index-browser.js",
     "dist/index.es.js": "./dist/index-browser.es.js",
-    "dist/index.mjs": "./dist/index-browser.mjs"
+    "dist/index.mjs": "./dist/index-browser.mjs",
+    "./dist/index.js": "./dist/index-browser.js",
+    "./dist/index.es.js": "./dist/index-browser.es.js",
+    "./dist/index.mjs": "./dist/index-browser.mjs"
   },
   "files": [
     "dist",


### PR DESCRIPTION
I was trying to migrate to use rollup for the browser bundle in https://github.com/inrupt/solid-client-authn-js/pull/3022.

The browser bundle being generated was bundling in the undici fetch rather than referring to the global one. This fixes that issue.