### PR TITLE
chore: add pre-releasing support to workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+
 
 jobs:
   publish-npm:
@@ -16,6 +18,15 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
       - run: npm ci
-      - run: npm publish --access public
+      - if: ${{ contains(github.ref_name, 'beta') }}
+        run: npm publish --access public --tag beta
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}
+      - if: ${{ contains(github.ref_name, 'alpha') }}
+        run: npm publish --access public --tag alpha
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}
+      - if: ${{ !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') }}
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}


### PR DESCRIPTION
Once this is merged we can create pre-releases by

1. Creating a new version `npm version pre[patch|minor|major] --preid [alpha|beta]` in a PR
2. Merging that to main
3. Create a new github tag & release with the same version number that gets created in (1) which will be of the format `v[0-9]+.[0-9]+.[0-9]+-[alpha|beta].[0-9]+`. Make sure we set this to be a pre-release in the GH UI.

These instruction need a better home long term, but I want to try and automate some of them first once we have agreement on the general approach.